### PR TITLE
fix edge case when handed an empty list of fns

### DIFF
--- a/directly.js
+++ b/directly.js
@@ -20,7 +20,7 @@ class Directly {
 	}
 
 	run () {
-		if (typeof this.funcs[0] !== 'function') {
+		if (this.funcs.length > 0 && typeof this.funcs[0] !== 'function') {
 			throw new TypeError('directly expects a list functions that return a Promise, not a list of Promises')
 		}
 		if (this.terminates) {


### PR DESCRIPTION
Should be able to handle an empty list of promise-returning fns, but barfs when handed one.
This tweak means it happily does nothing when handed an empty list (and doesn't barf).
Enjoy.