### PR TITLE
Resolve with empty array when passed empty array

### DIFF
--- a/directly.js
+++ b/directly.js
@@ -20,6 +20,10 @@ class Directly {
 	}
 
 	run () {
+		if (Array.isArray(this.funcs) && !this.funcs.length) {
+			return Promise.resolve([]);		
+		}
+
 		if (typeof this.funcs[0] !== 'function') {
 			throw new TypeError('directly expects a list functions that return a Promise, not a list of Promises')
 		}

--- a/test/directly.test.js
+++ b/test/directly.test.js
@@ -44,6 +44,22 @@ var getMutablePromise = function (n) {
 
 describe('concordance with Promise.all', function () {
 
+	describe('promise count is zero', function () {
+		it('should resolve with an empty array', function (done) {
+			var promises = setupPromises(0);
+
+			new Directly(3, promises.functions).run()
+				.then(function (res) {
+					expect(res).to.eql([]);
+					done();
+				});
+			promises.promises.forEach(function (p) {
+				p.resolve();
+			});
+
+		});
+	});
+
 	describe('promise count is under limit', function () {
 
 		it('should resolve if they all resolve', function (done) {


### PR DESCRIPTION
This mimics the behaviour for `Promise.all([])`.